### PR TITLE
Ltsmaint 481 c

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
     <spring.version>4.2.5.RELEASE</spring.version><!-- last release compatible with Camel 2.17.7 -->
     <openjpa.version>2.3.0</openjpa.version>
     <camel.version>2.17.7</camel.version><!-- last release for Java 1.7-->
-    <!--<aws-java-sdk.version>1.10.8</aws-java-sdk.version>-->
-    <aws-java-sdk.version>1.12.249</aws-java-sdk.version>
+    <aws-java-sdk.version>1.11.1034</aws-java-sdk.version>
+    <!--<aws-java-sdk.version>1.12.249</aws-java-sdk.version>-->
     <io.jsonwebtoken.version>0.10.7</io.jsonwebtoken.version>
     <resteasy.version>3.5.0.Final</resteasy.version>
     <junit.jupiter.version>5.2.0</junit.jupiter.version>
@@ -55,8 +55,8 @@
   <!--  aws jars -->
    <dependency>
      <groupId>com.amazonaws</groupId>
-     <!--<artifactId>aws-java-sdk</artifactId>-->
-     <artifactId>aws-java-sdk-bundle</artifactId>
+     <!--<artifactId>aws-java-sdk-bundle</artifactId>-->
+     <artifactId>aws-java-sdk</artifactId>
      <version>${aws-java-sdk.version}</version>
    </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
     <spring.version>4.2.5.RELEASE</spring.version><!-- last release compatible with Camel 2.17.7 -->
     <openjpa.version>2.3.0</openjpa.version>
     <camel.version>2.17.7</camel.version><!-- last release for Java 1.7-->
-    <aws-java-sdk.version>1.12.1</aws-java-sdk.version>
-    <!-- <aws-java-sdk.version>1.10.8</aws-java-sdk.version> -->
+    <!-- <aws-java-sdk.version>1.12.1</aws-java-sdk.version> -->
+    <aws-java-sdk.version>1.11.301</aws-java-sdk.version>
     <io.jsonwebtoken.version>0.10.7</io.jsonwebtoken.version>
     <resteasy.version>3.5.0.Final</resteasy.version>
     <junit.jupiter.version>5.2.0</junit.jupiter.version>
@@ -55,7 +55,7 @@
   <!--  aws jars -->
    <dependency>
      <groupId>com.amazonaws</groupId>
-     <artifactId>aws-java-sdk-bundle</artifactId>
+     <artifactId>aws-java-sdk</artifactId>
      <version>${aws-java-sdk.version}</version>
    </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,8 @@
     <spring.version>4.2.5.RELEASE</spring.version><!-- last release compatible with Camel 2.17.7 -->
     <openjpa.version>2.3.0</openjpa.version>
     <camel.version>2.17.7</camel.version><!-- last release for Java 1.7-->
-    <aws-java-sdk.version>1.12.1</aws-java-sdk.version>
+    <aws-java-sdk.version>1.10.8</aws-java-sdk.version>
+    <!--<aws-java-sdk.version>1.12.1</aws-java-sdk.version>-->
     <io.jsonwebtoken.version>0.10.7</io.jsonwebtoken.version>
     <resteasy.version>3.5.0.Final</resteasy.version>
     <junit.jupiter.version>5.2.0</junit.jupiter.version>
@@ -54,7 +55,8 @@
   <!--  aws jars -->
    <dependency>
      <groupId>com.amazonaws</groupId>
-     <artifactId>aws-java-sdk-bundle</artifactId>
+     <artifactId>aws-java-sdk</artifactId>
+     <!--<artifactId>aws-java-sdk-bundle</artifactId>-->
      <version>${aws-java-sdk.version}</version>
    </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <spring.version>4.2.5.RELEASE</spring.version><!-- last release compatible with Camel 2.17.7 -->
     <openjpa.version>2.3.0</openjpa.version>
     <camel.version>2.17.7</camel.version><!-- last release for Java 1.7-->
-    <aws-java-sdk.version>1.11.1034</aws-java-sdk.version>
+    <aws-java-sdk.version>1.10.77</aws-java-sdk.version>
     <!--<aws-java-sdk.version>1.12.249</aws-java-sdk.version>-->
     <io.jsonwebtoken.version>0.10.7</io.jsonwebtoken.version>
     <resteasy.version>3.5.0.Final</resteasy.version>

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
     <spring.version>4.2.5.RELEASE</spring.version><!-- last release compatible with Camel 2.17.7 -->
     <openjpa.version>2.3.0</openjpa.version>
     <camel.version>2.17.7</camel.version><!-- last release for Java 1.7-->
-    <aws-java-sdk.version>1.10.8</aws-java-sdk.version>
-    <!--<aws-java-sdk.version>1.12.1</aws-java-sdk.version>-->
+    <!--<aws-java-sdk.version>1.10.8</aws-java-sdk.version>-->
+    <aws-java-sdk.version>1.12.249</aws-java-sdk.version>
     <io.jsonwebtoken.version>0.10.7</io.jsonwebtoken.version>
     <resteasy.version>3.5.0.Final</resteasy.version>
     <junit.jupiter.version>5.2.0</junit.jupiter.version>
@@ -55,8 +55,8 @@
   <!--  aws jars -->
    <dependency>
      <groupId>com.amazonaws</groupId>
-     <artifactId>aws-java-sdk</artifactId>
-     <!--<artifactId>aws-java-sdk-bundle</artifactId>-->
+     <!--<artifactId>aws-java-sdk</artifactId>-->
+     <artifactId>aws-java-sdk-bundle</artifactId>
      <version>${aws-java-sdk.version}</version>
    </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,7 @@
     <spring.version>4.2.5.RELEASE</spring.version><!-- last release compatible with Camel 2.17.7 -->
     <openjpa.version>2.3.0</openjpa.version>
     <camel.version>2.17.7</camel.version><!-- last release for Java 1.7-->
-    <!-- <aws-java-sdk.version>1.12.1</aws-java-sdk.version> -->
-    <aws-java-sdk.version>1.11.301</aws-java-sdk.version>
+    <aws-java-sdk.version>1.12.1</aws-java-sdk.version>
     <io.jsonwebtoken.version>0.10.7</io.jsonwebtoken.version>
     <resteasy.version>3.5.0.Final</resteasy.version>
     <junit.jupiter.version>5.2.0</junit.jupiter.version>
@@ -55,7 +54,7 @@
   <!--  aws jars -->
    <dependency>
      <groupId>com.amazonaws</groupId>
-     <artifactId>aws-java-sdk</artifactId>
+     <artifactId>aws-java-sdk-bundle</artifactId>
      <version>${aws-java-sdk.version}</version>
    </dependency>
 

--- a/src/main/resources/viacomponent2mods.xsl
+++ b/src/main/resources/viacomponent2mods.xsl
@@ -161,7 +161,10 @@
 					<xsl:apply-templates select="surrogate"/>
 				</relatedItem>
 			</xsl:when>
-			<xsl:when
+			<xsl:when test="surrogate">
+				<xsl:apply-templates select="./surrogate" mode="surrInSW"/>
+			</xsl:when>
+			<!--<xsl:when
 				test="surrogate[tokenize(image/@href, '/')[last()] = $chunkid]">
 				<relatedItem type="constituent">
 					<xsl:call-template name="recordElements"/>
@@ -184,9 +187,35 @@
 					</recordInfo>
 					<xsl:apply-templates select="surrogate"/>
 				</relatedItem>
-			</xsl:when>
+			</xsl:when>-->
 			<xsl:otherwise/>
 		</xsl:choose>
+	</xsl:template>
+
+	<xsl:template match="surrogate" mode="surrInSW">
+		<xsl:if
+			test="(string-length($chunkid) and (contains(upper-case(image/@href), upper-case($chunkid)) or contains(upper-case(image/@xlink:href), upper-case($chunkid)))) or $chunkid = @componentID">
+			<relatedItem type="constituent">
+				<xsl:call-template name="recordElementsSubWSurr">
+					<xsl:with-param name="parentsw" select="ancestor::subwork"/>
+				</xsl:call-template>
+				<recordInfo>
+					<recordIdentifier>
+						<xsl:value-of select="ancestor::subwork/@componentID"/>
+					</recordIdentifier>
+				</recordInfo>
+				<relatedItem type="constituent">
+					<xsl:call-template name="recordElements"/>
+					<recordInfo>
+						<recordIdentifier>
+							<xsl:value-of select="@componentID"/>
+						</recordIdentifier>
+					</recordInfo>
+				</relatedItem>
+			</relatedItem>
+
+
+		</xsl:if>
 	</xsl:template>
 
 	<xsl:template match="surrogate">
@@ -201,6 +230,40 @@
 				</recordInfo>
 			</relatedItem>
 		</xsl:if>
+	</xsl:template>
+
+	<xsl:template name="recordElementsSubWSurr">
+		<xsl:param name="parentsw"/>
+		<xsl:apply-templates select="$parentsw/title[not(textElement = '')]"/>
+		<xsl:apply-templates select="$parentsw/creator"/>
+		<xsl:apply-templates select="$parentsw/associatedName"/>
+		<!--<xsl:call-template name="typeOfResource"/>-->
+		<xsl:apply-templates select="$parentsw/workType"/>
+		<!--<xsl:call-template name="originInfo"/>-->
+		<!--xsl:apply-templates select="production"/>
+		<xsl:apply-templates select="structuredDate"/>
+		<xsl:apply-templates select="freeDate"/>
+		<xsl:apply-templates select="state"/-->
+		<!--xsl:apply-templates select="physicalDescription"/>
+		<xsl:apply-templates select="dimensions"/>
+		<xsl:apply-templates select="workType"/-->
+		<!--<xsl:call-template name="physicalDescription"/>-->
+		<xsl:apply-templates select="$parentsw/description"/>
+		<xsl:apply-templates select="$parentsw/notes"/>
+		<xsl:apply-templates select="$parentsw/placeName"/>
+		<xsl:apply-templates select="$parentsw/topic"/>
+		<xsl:apply-templates select="$parentsw/style"/>
+		<xsl:apply-templates select="$parentsw/culture"/>
+		<xsl:apply-templates select="$parentsw/materials"/>
+		<xsl:apply-templates select="$parentsw/classification"/>
+		<xsl:apply-templates select="$parentsw/relatedWork"/>
+		<xsl:apply-templates select="$parentsw/relatedInformation"/>
+		<xsl:apply-templates select="$parentsw/itemIdentifier"/>
+		<xsl:apply-templates select="$parentsw/image"/>
+		<xsl:apply-templates select="$parentsw/repository"/>
+		<xsl:apply-templates select="$parentsw/location"/>
+		<xsl:apply-templates select="$parentsw/useRestrictions"/>
+		<xsl:apply-templates select="$parentsw/copyright"/>
 	</xsl:template>
 
 	<xsl:template name="recordElements">

--- a/src/main/resources/viacomponent2mods.xsl
+++ b/src/main/resources/viacomponent2mods.xsl
@@ -237,9 +237,43 @@
 		<xsl:apply-templates select="$parentsw/title[not(textElement = '')]"/>
 		<xsl:apply-templates select="$parentsw/creator"/>
 		<xsl:apply-templates select="$parentsw/associatedName"/>
-		<!--<xsl:call-template name="typeOfResource"/>-->
+		<xsl:call-template name="typeOfResource"/>
 		<xsl:apply-templates select="$parentsw/workType"/>
 		<!--<xsl:call-template name="originInfo"/>-->
+		<xsl:if test="$parentsw/production | $parentsw/structuredDate | $parentsw/freeDate | $parentsw/state">
+			<originInfo>
+				<xsl:if test="$parentsw/production/placeOfProduction/place">
+					<place>
+						<placeTerm>
+							<xsl:value-of select="$parentsw/production/placeOfProduction/place"/>
+						</placeTerm>
+					</place>
+				</xsl:if>
+				<xsl:if test="$parentsw/production/producer">
+					<publisher>
+						<xsl:value-of select="$parentsw/production/producer"/>
+					</publisher>
+				</xsl:if>
+				<!-- dateOther keyDate is used for date sorting -->
+				<!-- 2015-02-27 - but only for work/group-level-->
+				<xsl:if test="$parentsw/structuredDate/beginDate">
+					<xsl:apply-templates select="$parentsw/structuredDate[1]/beginDate"/>
+				</xsl:if>
+				<xsl:if test="$parentsw/structuredDate/endDate">
+					<xsl:apply-templates select="$parentsw/structuredDate[1]/endDate"/>
+				</xsl:if>
+				<xsl:if test="$parentsw/freeDate">
+					<dateCreated>
+						<xsl:value-of select="$parentsw/freeDate"/>
+					</dateCreated>
+				</xsl:if>
+				<xsl:if test="$parentsw/state">
+					<edition>
+						<xsl:value-of select="$parentsw/state"/>
+					</edition>
+				</xsl:if>
+			</originInfo>
+		</xsl:if>
 		<!--xsl:apply-templates select="production"/>
 		<xsl:apply-templates select="structuredDate"/>
 		<xsl:apply-templates select="freeDate"/>
@@ -248,6 +282,20 @@
 		<xsl:apply-templates select="dimensions"/>
 		<xsl:apply-templates select="workType"/-->
 		<!--<xsl:call-template name="physicalDescription"/>-->
+		<xsl:if test="$parentsw/physicalDescription or $parentsw/dimensions">
+			<physicalDescription>
+				<xsl:if test="$parentsw/physicalDescription">
+					<note>
+						<xsl:value-of select="$parentsw/physicalDescription"/>
+					</note>
+				</xsl:if>
+				<xsl:if test="$parentsw/dimensions">
+					<extent>
+						<xsl:value-of select="$parentsw/dimensions"/>
+					</extent>
+				</xsl:if>
+			</physicalDescription>
+		</xsl:if>
 		<xsl:apply-templates select="$parentsw/description"/>
 		<xsl:apply-templates select="$parentsw/notes"/>
 		<xsl:apply-templates select="$parentsw/placeName"/>
@@ -298,6 +346,8 @@
 		<xsl:apply-templates select="useRestrictions"/>
 		<xsl:apply-templates select="copyright"/>
 	</xsl:template>
+
+
 
 	<xsl:template match="title">
 		<xsl:element name="titleInfo">

--- a/src/main/resources/viacomponent2mods.xsl
+++ b/src/main/resources/viacomponent2mods.xsl
@@ -162,7 +162,7 @@
 				</relatedItem>
 			</xsl:when>
 			<xsl:when
-				test="surrogate[tokenize(image/attribute::node()[local-name() = 'href'], '/')[last()] = $chunkid]">
+				test="surrogate[tokenize(image/@href, '/')[last()] = $chunkid]">
 				<relatedItem type="constituent">
 					<xsl:call-template name="recordElements"/>
 					<recordInfo>
@@ -170,22 +170,23 @@
 							<xsl:value-of select="@componentID"/>
 						</recordIdentifier>
 					</recordInfo>
-					<xsl:apply-templates select="surrogate" mode="surrInSubwork"/>
+					<xsl:apply-templates select="surrogate"/>
+				</relatedItem>
+			</xsl:when>
+			<xsl:when
+				test="surrogate[tokenize(image/@xlink:href, '/')[last()] = $chunkid]">
+				<relatedItem type="constituent">
+					<xsl:call-template name="recordElements"/>
+					<recordInfo>
+						<recordIdentifier>
+							<xsl:value-of select="@componentID"/>
+						</recordIdentifier>
+					</recordInfo>
+					<xsl:apply-templates select="surrogate"/>
 				</relatedItem>
 			</xsl:when>
 			<xsl:otherwise/>
 		</xsl:choose>
-	</xsl:template>
-
-	<xsl:template match="surrogate" mode="surrInSubwork">
-		<relatedItem type="constituent">
-			<xsl:call-template name="recordElements"/>
-			<recordInfo>
-				<recordIdentifier>
-					<xsl:value-of select="@componentID"/>
-				</recordIdentifier>
-			</recordInfo>
-		</relatedItem>
 	</xsl:template>
 
 	<xsl:template match="surrogate">

--- a/src/main/resources/viacomponent2mods.xsl
+++ b/src/main/resources/viacomponent2mods.xsl
@@ -11,7 +11,7 @@
 
 	<xsl:output method="xml" omit-xml-declaration="yes" version="1.0" encoding="UTF-8" indent="yes"/>
 	<!--<xsl:param name="urn">http://nrs.harvard.edu/urn-3:FMUS:27510</xsl:param>-->
-	<xsl:param name="chunkid"/>
+	<xsl:param name="chunkid"></xsl:param>
 	<!--<xsl:param name="chunkid">urn-3:FHCL:3599019</xsl:param>-->
 	<!--<xsl:param name="nodeComponentID" />-->
 	<xsl:template match="/viaRecord">

--- a/src/main/resources/viacomponent2mods.xsl
+++ b/src/main/resources/viacomponent2mods.xsl
@@ -11,7 +11,7 @@
 
 	<xsl:output method="xml" omit-xml-declaration="yes" version="1.0" encoding="UTF-8" indent="yes"/>
 	<!--<xsl:param name="urn">http://nrs.harvard.edu/urn-3:FMUS:27510</xsl:param>-->
-	<xsl:param name="chunkid"></xsl:param>
+	<xsl:param name="chunkid">urn-3:FHCL:3599019</xsl:param>
 	<!--<xsl:param name="chunkid">urn-3:FHCL:3599019</xsl:param>-->
 	<!--<xsl:param name="nodeComponentID" />-->
 	<xsl:template match="/viaRecord">
@@ -126,7 +126,8 @@
 
 	<xsl:template match="subwork">
 		<xsl:choose>
-			<xsl:when test="contains(upper-case(image/@href), upper-case($chunkid)) and string-length(image/@href)">
+			<xsl:when
+				test="contains(upper-case(image/@href), upper-case($chunkid)) and string-length(image/@href)">
 				<relatedItem type="constituent">
 					<xsl:call-template name="recordElements"/>
 					<recordInfo>
@@ -161,7 +162,7 @@
 				</relatedItem>
 			</xsl:when>
 			<xsl:when
-				test="surrogate[upper-case(tokenize(image/attribute::node()[local-name() = 'href'], '/')[last()]) = upper-case($chunkid)]">
+				test="surrogate[tokenize(image/attribute::node()[local-name() = 'href'], '/')[last()] = $chunkid]">
 				<relatedItem type="constituent">
 					<xsl:call-template name="recordElements"/>
 					<recordInfo>
@@ -169,11 +170,22 @@
 							<xsl:value-of select="@componentID"/>
 						</recordIdentifier>
 					</recordInfo>
-					<xsl:apply-templates select="surrogate"/>
+					<xsl:apply-templates select="surrogate" mode="surrInSubwork"/>
 				</relatedItem>
 			</xsl:when>
 			<xsl:otherwise/>
 		</xsl:choose>
+	</xsl:template>
+
+	<xsl:template match="surrogate" mode="surrInSubwork">
+		<relatedItem type="constituent">
+			<xsl:call-template name="recordElements"/>
+			<recordInfo>
+				<recordIdentifier>
+					<xsl:value-of select="@componentID"/>
+				</recordIdentifier>
+			</recordInfo>
+		</relatedItem>
 	</xsl:template>
 
 	<xsl:template match="surrogate">

--- a/src/main/resources/viacomponent2mods.xsl
+++ b/src/main/resources/viacomponent2mods.xsl
@@ -11,7 +11,7 @@
 
 	<xsl:output method="xml" omit-xml-declaration="yes" version="1.0" encoding="UTF-8" indent="yes"/>
 	<!--<xsl:param name="urn">http://nrs.harvard.edu/urn-3:FMUS:27510</xsl:param>-->
-	<xsl:param name="chunkid">urn-3:FHCL:3599019</xsl:param>
+	<xsl:param name="chunkid"></xsl:param>
 	<!--<xsl:param name="chunkid">urn-3:FHCL:3599019</xsl:param>-->
 	<!--<xsl:param name="nodeComponentID" />-->
 	<xsl:template match="/viaRecord">

--- a/src/main/resources/viacomponent2mods.xsl
+++ b/src/main/resources/viacomponent2mods.xsl
@@ -11,7 +11,7 @@
 
 	<xsl:output method="xml" omit-xml-declaration="yes" version="1.0" encoding="UTF-8" indent="yes"/>
 	<!--<xsl:param name="urn">http://nrs.harvard.edu/urn-3:FMUS:27510</xsl:param>-->
-	<xsl:param name="chunkid"/>
+	<xsl:param name="chunkid"></xsl:param>
 	<!--<xsl:param name="chunkid">urn-3:FHCL:3599019</xsl:param>-->
 	<!--<xsl:param name="nodeComponentID" />-->
 	<xsl:template match="/viaRecord">
@@ -326,7 +326,7 @@
 				</xsl:when>
 			</xsl:choose>
 			<xsl:element name="title">
-				<xsl:value-of select="normalize-space(textElement)"/><xsl:text>: TEST</xsl:text>
+				<xsl:value-of select="normalize-space(textElement)"/>
 			</xsl:element>
 		</xsl:element>
 	</xsl:template>

--- a/src/main/resources/viacomponent2mods.xsl
+++ b/src/main/resources/viacomponent2mods.xsl
@@ -12,7 +12,7 @@
 	<xsl:output method="xml" omit-xml-declaration="yes" version="1.0" encoding="UTF-8" indent="yes"/>
 	<!--<xsl:param name="urn">http://nrs.harvard.edu/urn-3:FMUS:27510</xsl:param>-->
 	<xsl:param name="chunkid"/>
-	<!--<xsl:param name="chunkid">urn-3:FHCL:3599021</xsl:param>-->
+	<!--<xsl:param name="chunkid">urn-3:FHCL:3599019</xsl:param>-->
 	<!--<xsl:param name="nodeComponentID" />-->
 	<xsl:template match="/viaRecord">
 		<!--<xsl:message>URN: <xsl:value-of select="$urn"/></xsl:message>
@@ -126,7 +126,7 @@
 
 	<xsl:template match="subwork">
 		<xsl:choose>
-			<xsl:when test="contains(image/@href, $chunkid) and string-length(image/@href)">
+			<xsl:when test="contains(upper-case(image/@href), upper-case($chunkid)) and string-length(image/@href)">
 				<relatedItem type="constituent">
 					<xsl:call-template name="recordElements"/>
 					<recordInfo>
@@ -138,7 +138,7 @@
 				</relatedItem>
 			</xsl:when>
 			<xsl:when
-				test="contains(image/@xlink:href, $chunkid) and string-length(image/@xlink:href)">
+				test="contains(upper-case(image/@xlink:href), upper-case($chunkid)) and string-length(image/@xlink:href)">
 				<relatedItem type="constituent">
 					<xsl:call-template name="recordElements"/>
 					<recordInfo>
@@ -161,7 +161,7 @@
 				</relatedItem>
 			</xsl:when>
 			<xsl:when
-				test="surrogate[tokenize(image/attribute::node()[local-name() = 'href'], '/')[last()] = $chunkid]">
+				test="surrogate[upper-case(tokenize(image/attribute::node()[local-name() = 'href'], '/')[last()]) = upper-case($chunkid)]">
 				<relatedItem type="constituent">
 					<xsl:call-template name="recordElements"/>
 					<recordInfo>
@@ -178,7 +178,7 @@
 
 	<xsl:template match="surrogate">
 		<xsl:if
-			test="(string-length($chunkid) and (contains(image/@href, $chunkid) or contains(image/@xlink:href, $chunkid))) or $chunkid = @componentID">
+			test="(string-length($chunkid) and (contains(upper-case(image/@href), upper-case($chunkid)) or contains(upper-case(image/@xlink:href), upper-case($chunkid)))) or $chunkid = @componentID">
 			<relatedItem type="constituent">
 				<xsl:call-template name="recordElements"/>
 				<recordInfo>

--- a/src/main/resources/viacomponent2mods.xsl
+++ b/src/main/resources/viacomponent2mods.xsl
@@ -11,7 +11,7 @@
 
 	<xsl:output method="xml" omit-xml-declaration="yes" version="1.0" encoding="UTF-8" indent="yes"/>
 	<!--<xsl:param name="urn">http://nrs.harvard.edu/urn-3:FMUS:27510</xsl:param>-->
-	<xsl:param name="chunkid"></xsl:param>
+	<xsl:param name="chunkid"/>
 	<!--<xsl:param name="chunkid">urn-3:FHCL:3599019</xsl:param>-->
 	<!--<xsl:param name="nodeComponentID" />-->
 	<xsl:template match="/viaRecord">
@@ -326,7 +326,7 @@
 				</xsl:when>
 			</xsl:choose>
 			<xsl:element name="title">
-				<xsl:value-of select="normalize-space(textElement)"/>
+				<xsl:value-of select="normalize-space(textElement)"/><xsl:text>: TEST</xsl:text>
 			</xsl:element>
 		</xsl:element>
 	</xsl:template>


### PR DESCRIPTION
Description: This pr addresses outstanding xslt issues for converting jstor group records (with surrogates within subworks). Also, we settled on aws java sdk 1.10.77 as an intermediate step to full upgrade to either 1.12x or 2x (neither of which work currently with libcloud ingest). 

Jira ticket: https://jira.huit.harvard.edu/browse/LTSMAINT-266 (note 481 is a subtask of 266 dealing with the xsl issue)

Testing: This version has been deployed to qa and tested (xslt an aws sdk both working).